### PR TITLE
filesystems: This  makes it so that datapacks can be reloaded with /reload

### DIFF
--- a/src/main/java/li/cil/oc2/common/CommonSetup.java
+++ b/src/main/java/li/cil/oc2/common/CommonSetup.java
@@ -29,6 +29,7 @@ public final class CommonSetup {
         FMLJavaModLoadingContext.get().getModEventBus().addListener(IMC::handleIMCMessages);
         MinecraftForge.EVENT_BUS.addListener(CommonSetup::handleServerAboutToStart);
         MinecraftForge.EVENT_BUS.addListener(CommonSetup::handleServerStopped);
+        MinecraftForge.EVENT_BUS.addListener(FileSystems::addReloadListenerEvent);
         ServerScheduler.register();
 
         addBuiltinRPCMethodParameterTypeAdapters();
@@ -38,7 +39,6 @@ public final class CommonSetup {
 
     private static void handleServerAboutToStart(final FMLServerAboutToStartEvent event) {
         BlobStorage.setServer(event.getServer());
-        FileSystems.initialize(event.getServer());
     }
 
     private static void handleServerStopped(final FMLServerStoppedEvent event) {

--- a/src/main/java/li/cil/oc2/common/bus/device/data/FileSystems.java
+++ b/src/main/java/li/cil/oc2/common/bus/device/data/FileSystems.java
@@ -1,5 +1,7 @@
 package li.cil.oc2.common.bus.device.data;
 
+import java.util.concurrent.Executor;
+import java.util.concurrent.CompletableFuture;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import li.cil.oc2.common.vm.fs.LayeredFileSystem;
@@ -7,8 +9,11 @@ import li.cil.oc2.common.vm.fs.ResourceFileSystem;
 import li.cil.sedna.fs.FileSystem;
 import net.minecraft.resources.IResource;
 import net.minecraft.resources.IResourceManager;
+import net.minecraft.resources.IFutureReloadListener;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.profiler.IProfiler;
+import net.minecraftforge.event.AddReloadListenerEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -17,47 +22,63 @@ import java.util.Collection;
 
 public final class FileSystems {
     private static final Logger LOGGER = LogManager.getLogger();
-
     private static final LayeredFileSystem LAYERED_FILE_SYSTEM = new LayeredFileSystem();
+    
+    private static final IFutureReloadListener RELOAD_LISTENER = new IFutureReloadListener() {
+            @Override
+            public String getSimpleName() {
+                return "oc2:file_system";
+            };
+            
+            @Override
+            public CompletableFuture<Void> reload(IFutureReloadListener.IStage stage, IResourceManager resourceManager, IProfiler preparaationsProfiler, IProfiler reloadProfiler, Executor backgroundExecutor, Executor gameExecutor) {
+                return CompletableFuture.runAsync(() -> {
+                        LAYERED_FILE_SYSTEM.clear();
 
+                        LOGGER.info("Searching for datapack filesystems!");
+                        final Collection<ResourceLocation> fileSystemDescriptorLocations = resourceManager
+                            .getAllResourceLocations("file_systems", s -> s.endsWith(".fs.json"));
+
+                        for (final ResourceLocation fileSystemDescriptorLocation : fileSystemDescriptorLocations) {
+                            LOGGER.info("Found [{}]", fileSystemDescriptorLocation);
+                            try {
+                                final IResource fileSystemDescriptor = resourceManager.getResource(fileSystemDescriptorLocation);
+                                final JsonObject json = new JsonParser().parse(new InputStreamReader(fileSystemDescriptor.getInputStream())).getAsJsonObject();
+                                final String type = json.getAsJsonPrimitive("type").getAsString();
+                                switch (type) {
+                                case "virtio-9p": {
+                                    final ResourceLocation location = new ResourceLocation(json.getAsJsonPrimitive("location").getAsString());
+                                    final ResourceFileSystem fileSystem = new ResourceFileSystem(resourceManager, location);
+                                    LAYERED_FILE_SYSTEM.addLayer(fileSystem);
+                                    break;
+                                }
+                                case "virtio-blk": {
+                                    LOGGER.error("Not yet implemented.");
+                                    break;
+                                }
+                                default: {
+                                    LOGGER.error("Unsupported file system type [{}].", type);
+                                    break;
+                                }
+                                }
+                            } catch (final Throwable e) {
+                                LOGGER.error(e);
+                            }
+                        }
+                    }, backgroundExecutor)
+                    .thenCompose(stage::markCompleteAwaitingOthers);
+            }
+        };
+
+    
     public static FileSystem getLayeredFileSystem() {
         return LAYERED_FILE_SYSTEM;
     }
 
-    public static void initialize(final MinecraftServer server) {
-        reset();
 
-        final IResourceManager resourceManager = server.getDataPackRegistries().getResourceManager();
-
-        final Collection<ResourceLocation> fileSystemDescriptorLocations = resourceManager
-                .getAllResourceLocations("file_systems", s -> s.endsWith(".fs.json"));
-
-        for (final ResourceLocation fileSystemDescriptorLocation : fileSystemDescriptorLocations) {
-            try {
-                final IResource fileSystemDescriptor = resourceManager.getResource(fileSystemDescriptorLocation);
-                final JsonObject json = new JsonParser().parse(new InputStreamReader(fileSystemDescriptor.getInputStream())).getAsJsonObject();
-                final String type = json.getAsJsonPrimitive("type").getAsString();
-                switch (type) {
-                    case "virtio-9p": {
-                        final ResourceLocation location = new ResourceLocation(json.getAsJsonPrimitive("location").getAsString());
-                        final ResourceFileSystem fileSystem = new ResourceFileSystem(resourceManager, location);
-                        LAYERED_FILE_SYSTEM.addLayer(fileSystem);
-                        break;
-                    }
-                    case "virtio-blk": {
-                        LOGGER.error("Not yet implemented.");
-                        break;
-                    }
-                    default: {
-                        LOGGER.error("Unsupported file system type [{}].", type);
-                        break;
-                    }
-                }
-            } catch (final Throwable e) {
-                LOGGER.error(e);
-            }
-        }
-    }
+    public static void addReloadListenerEvent(final AddReloadListenerEvent event) {
+        event.addListener(RELOAD_LISTENER);
+    };
 
     public static void reset() {
         LAYERED_FILE_SYSTEM.clear();


### PR DESCRIPTION
I'm not clear on if the datapack support worked in the first place, but at the very least this PR changes it so that datapacks can be reloaded using the standard MC `/reload` command.


( The reason I'm not sure if datapack loading was working in the first place is because my test-datapack was invalid until I got half-way through this code change )