### PR TITLE
Concurrency bug in RPCDeviceBusAdapter.java fix

### DIFF
--- a/src/main/java/li/cil/oc2/common/bus/RPCDeviceBusAdapter.java
+++ b/src/main/java/li/cil/oc2/common/bus/RPCDeviceBusAdapter.java
@@ -390,7 +390,7 @@ public final class RPCDeviceBusAdapter implements Steppable {
         if (receiveBuffer != null) throw new IllegalStateException();
         final String json = gson.toJson(new Message(type, data));
         final byte[] bytes = json.getBytes();
-        receiveBuffer = ByteBuffer.allocate(bytes.length + MESSAGE_DELIMITER.length * 2);
+        final ByteBuffer receiveBuffer = ByteBuffer.allocate(bytes.length + MESSAGE_DELIMITER.length * 2);
 
         // In case we went through a reset and the VM was in the middle of reading
         // a message we inject a delimiter up front to cause the truncated message
@@ -405,6 +405,7 @@ public final class RPCDeviceBusAdapter implements Steppable {
         receiveBuffer.put(MESSAGE_DELIMITER);
 
         receiveBuffer.flip();
+        this.receiveBuffer = receiveBuffer;
     }
 
     ///////////////////////////////////////////////////////////////////


### PR DESCRIPTION
I recently tried this mod on my server and everything worked fine. But today, while trying to log into the server, I encountered a `java.nio.BufferOverflowException` error that occurred in the `RPCDeviceBusAdapter` class. I tried to figure out what was the matter. As a result, I came to the conclusion that two methods of this class simultaneously change the data in the `receiveBuffer` variable. The main game thread writes to the `receiveBuffer`, and the virtual machine thread reads from the `receiveBuffer`.

I fixed this bug by using a local variable with the same name, which is only assigned to the class variable when the changes are complete and ready to be read in the virtual machine thread.

If I understand everything correctly, then the `writeMessage` method will never be executed in two threads at the same time, so the proposed changes should be sufficient.

### Crash report

```
---- Minecraft Crash Report ----
// Shall we play a game?

Time: 01.08.21 19:09
Description: Ticking block entity

java.nio.BufferOverflowException: null
	at java.nio.HeapByteBuffer.put(HeapByteBuffer.java:194) ~[?:1.8.0_292] {}
	at java.nio.ByteBuffer.put(ByteBuffer.java:867) ~[?:1.8.0_292] {}
	at li.cil.oc2.common.bus.RPCDeviceBusAdapter.writeMessage(RPCDeviceBusAdapter.java:400) ~[?:?] {re:classloading}
	at li.cil.oc2.common.bus.RPCDeviceBusAdapter.writeError(RPCDeviceBusAdapter.java:386) ~[?:?] {re:classloading}
	at li.cil.oc2.common.bus.RPCDeviceBusAdapter.invokeMethod(RPCDeviceBusAdapter.java:335) ~[?:?] {re:classloading}
	at li.cil.oc2.common.bus.RPCDeviceBusAdapter.processMethodInvocation(RPCDeviceBusAdapter.java:308) ~[?:?] {re:classloading}
	at li.cil.oc2.common.bus.RPCDeviceBusAdapter.tick(RPCDeviceBusAdapter.java:156) ~[?:?] {re:classloading}
	at li.cil.oc2.common.vm.VMRunner.tick(VMRunner.java:70) ~[?:?] {re:classloading}
	at li.cil.oc2.common.vm.AbstractVirtualMachine.run(AbstractVirtualMachine.java:371) ~[?:?] {re:classloading,pl:runtimedistcleaner:A}
	at li.cil.oc2.common.vm.AbstractVirtualMachine.tick(AbstractVirtualMachine.java:227) ~[?:?] {re:classloading,pl:runtimedistcleaner:A}
	at li.cil.oc2.common.tileentity.ComputerTileEntity$ComputerVirtualMachine.tick(ComputerTileEntity.java:386) ~[?:?] {re:classloading}
	at li.cil.oc2.common.tileentity.ComputerTileEntity.tick(ComputerTileEntity.java:186) ~[?:?] {re:classloading}
	at net.minecraft.world.World.tickBlockEntities(World.java:491) ~[forge:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.world.server.ServerWorld.tick(ServerWorld.java:371) ~[forge:?] {re:classloading,pl:runtimedistcleaner:A}
	at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:851) ~[forge:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:291) ~[forge:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:787) ~[forge:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:642) ~[forge:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:232) ~[forge:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_292] {}


A detailed walkthrough of the error, its code path and all known details is as follows:
---------------------------------------------------------------------------------------

-- Head --
Thread: Server thread
Stacktrace:
	at java.nio.HeapByteBuffer.put(HeapByteBuffer.java:194) ~[?:1.8.0_292] {}
	at java.nio.ByteBuffer.put(ByteBuffer.java:867) ~[?:1.8.0_292] {}
	at li.cil.oc2.common.bus.RPCDeviceBusAdapter.writeMessage(RPCDeviceBusAdapter.java:400) ~[?:?] {re:classloading}
	at li.cil.oc2.common.bus.RPCDeviceBusAdapter.writeError(RPCDeviceBusAdapter.java:386) ~[?:?] {re:classloading}
	at li.cil.oc2.common.bus.RPCDeviceBusAdapter.invokeMethod(RPCDeviceBusAdapter.java:335) ~[?:?] {re:classloading}
	at li.cil.oc2.common.bus.RPCDeviceBusAdapter.processMethodInvocation(RPCDeviceBusAdapter.java:308) ~[?:?] {re:classloading}
	at li.cil.oc2.common.bus.RPCDeviceBusAdapter.tick(RPCDeviceBusAdapter.java:156) ~[?:?] {re:classloading}
	at li.cil.oc2.common.vm.VMRunner.tick(VMRunner.java:70) ~[?:?] {re:classloading}
	at li.cil.oc2.common.vm.AbstractVirtualMachine.run(AbstractVirtualMachine.java:371) ~[?:?] {re:classloading,pl:runtimedistcleaner:A}
	at li.cil.oc2.common.vm.AbstractVirtualMachine.tick(AbstractVirtualMachine.java:227) ~[?:?] {re:classloading,pl:runtimedistcleaner:A}
	at li.cil.oc2.common.tileentity.ComputerTileEntity$ComputerVirtualMachine.tick(ComputerTileEntity.java:386) ~[?:?] {re:classloading}
	at li.cil.oc2.common.tileentity.ComputerTileEntity.tick(ComputerTileEntity.java:186) ~[?:?] {re:classloading}
-- Block entity being ticked --
Details:
	Name: oc2:computer // li.cil.oc2.common.tileentity.ComputerTileEntity
	Block: Block{oc2:computer}[facing=east]
	Block location: World: (-121,77,133), Chunk: (at 7,4,5 in -8,8; contains blocks -128,0,128 to -113,255,143), Region: (-1,0; contains chunks -32,0 to -1,31, blocks -512,0,0 to -1,255,511)
	Block: Block{oc2:computer}[facing=east]
	Block location: World: (-121,77,133), Chunk: (at 7,4,5 in -8,8; contains blocks -128,0,128 to -113,255,143), Region: (-1,0; contains chunks -32,0 to -1,31, blocks -512,0,0 to -1,255,511)
Stacktrace:
	at net.minecraft.world.World.tickBlockEntities(World.java:491) ~[forge:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.world.server.ServerWorld.tick(ServerWorld.java:371) ~[forge:?] {re:classloading,pl:runtimedistcleaner:A}


-- Affected level --
Details:
	All players: 1 total; [ServerPlayerEntity['Ktlo'/129, l='ServerLevel[SSH]', x=-136.57, y=93.33, z=145.57]]
	Chunk stats: ServerChunkCache: 2537
	Level dimension: minecraft:overworld
	Level spawn location: World: (160,92,195), Chunk: (at 0,5,3 in 10,12; contains blocks 160,0,192 to 175,255,207), Region: (0,0; contains chunks 0,0 to 31,31, blocks 0,0,0 to 511,255,511)
	Level time: 1511027 game time, 6000 day time
	Level name: SSH
	Level game mode: Game mode: survival (ID 0). Hardcore: false. Cheats: true
	Level weather: Rain time: 10541 (now: false), thunder time: 17037 (now: false)
	Known server brands: forge
	Level was modded: true
	Level storage version: 0x04ABD - Anvil
Stacktrace:
	at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:851) ~[forge:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:291) ~[forge:?] {re:classloading,pl:accesstransformer:B}
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:787) ~[forge:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:642) ~[forge:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:232) ~[forge:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_292] {}


-- System Details --
Details:
	Minecraft Version: 1.16.5
	Minecraft Version ID: 1.16.5
	Operating System: Linux (amd64) version 5.10.0-8-amd64
	Java Version: 1.8.0_292, AdoptOpenJDK
	Java VM Version: OpenJDK 64-Bit Server VM (mixed mode), AdoptOpenJDK
	Memory: 1291126352 bytes (1231 MB) / 1887436800 bytes (1800 MB) up to 3693084672 bytes (3522 MB)
	CPUs: 8
	JVM Flags: 0 total; 
	ModLauncher: 8.0.9+86+master.3cf110c
	ModLauncher launch target: fmluserdevserver
	ModLauncher naming: mcp
	ModLauncher services: 
		/mixin-0.8.2.jar mixin PLUGINSERVICE 
		/eventbus-4.0.0.jar eventbus PLUGINSERVICE 
		/forge-1.16.5-36.1.32_mapped_official_1.16.5-launcher.jar object_holder_definalize PLUGINSERVICE 
		/forge-1.16.5-36.1.32_mapped_official_1.16.5-launcher.jar runtime_enum_extender PLUGINSERVICE 
		/accesstransformers-3.0.1.jar accesstransformer PLUGINSERVICE 
		/forge-1.16.5-36.1.32_mapped_official_1.16.5-launcher.jar capability_inject_definalize PLUGINSERVICE 
		/forge-1.16.5-36.1.32_mapped_official_1.16.5-launcher.jar runtimedistcleaner PLUGINSERVICE 
		/mixin-0.8.2.jar mixin TRANSFORMATIONSERVICE 
		/forge-1.16.5-36.1.32_mapped_official_1.16.5-launcher.jar fml TRANSFORMATIONSERVICE 
	FML: 36.1
	Forge: net.minecraftforge:36.1.32
	FML Language Providers: 
		javafml@36.1
		minecraft@1
	Mod List: 
		client-extra.jar                                  |Minecraft                     |minecraft                     |1.16.5              |DONE      |Manifest: a1:d4:5e:04:4f:d3:d6:e0:7b:37:97:cf:77:b0:de:ad:4a:47:ce:8c:96:49:5f:0a:cf:8c:ae:b2:6d:4b:8a:3f
		sedna-mc-MC1.16.5-Forge-1.0.1+271.jar             |Sedna for Minecraft           |oc2-sedna                     |1.0.1+271           |DONE      |Manifest: NOSIGNATURE
		forge-1.16.5-36.1.32_mapped_official_1.16.5-recomp|Forge                         |forge                         |36.1.32             |DONE      |Manifest: NOSIGNATURE
		MarkdownManual-MC1.16.5-Forge-1.0.1+_mapped_offici|MarkdownManual                |markdown_manual               |1.0.1+15            |DONE      |Manifest: NOSIGNATURE
		main                                              |OpenComputers II              |oc2                           |0.0.1+235bc3b       |DONE      |Manifest: NOSIGNATURE
		jei-1.16.4-7.6.1.71_mapped_official_1.16.5.jar    |Just Enough Items             |jei                           |7.6.1.71            |DONE      |Manifest: NOSIGNATURE
	Crash Report UUID: f2d11bf5-a6d6-4078-97b9-a035a31202a5
	Player Count: 1 / 20; [ServerPlayerEntity['Ktlo'/129, l='ServerLevel[SSH]', x=-136.57, y=93.33, z=145.57]]
	Data Packs: vanilla, mod:oc2-sedna (incompatible), mod:forge, mod:markdown_manual (incompatible), mod:oc2 (incompatible), mod:jei
	Is Modded: Definitely; Server brand changed to 'forge'
	Type: Dedicated Server (map_server.txt)
```