### PR TITLE
build: Fix the oc2-sedna -> sedna rename

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,7 @@ processResources {
                 'mod_issues_url'       : mod_issues_url,
                 'forge_version_min'    : forge_version_min,
                 'minecraft_version_min': minecraft_version_min,
-                'oc2_sedna_version_min': oc2_sedna_version_min,
+                'sedna_version_min'    : sedna_version_min,
                 'manual_version_min'   : manual_version,
         ])
     }

--- a/build.gradle
+++ b/build.gradle
@@ -61,8 +61,8 @@ dependencies {
     implementation "li.cil.sedna:sedna:1.0.1+101"
     implementation "li.cil.sedna:sedna-buildroot:0.0.1+15"
 
-    compileOnly fg.deobf("li.cil.markdown_manual:MarkdownManual:MC${minecraft_version}-Forge-${manual_version}:api")
-    runtimeOnly fg.deobf("li.cil.markdown_manual:MarkdownManual:MC${minecraft_version}-Forge-${manual_version}")
+    compileOnly fg.deobf("li.cil.markdown_manual:MarkdownManual:MC${minecraft_version}-Forge-${manual_version}+:api")
+    runtimeOnly fg.deobf("li.cil.markdown_manual:MarkdownManual:MC${minecraft_version}-Forge-${manual_version}+")
 
     compileOnly fg.deobf("mezz.jei:jei-${jei_minecraft_version}:${jei_version}:api")
     runtimeOnly fg.deobf("mezz.jei:jei-${jei_minecraft_version}:${jei_version}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ version_major=0
 version_minor=0
 version_patch=1
 
-oc2_sedna_version_min=0.0.1
+sedna_version_min=0.0.1
 manual_version=1.1.0+
 
 jei_minecraft_version=1.16.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ version_minor=0
 version_patch=1
 
 sedna_version_min=0.0.1
-manual_version=1.1.0+
+manual_version=1.1.0
 
 jei_minecraft_version=1.16.4
 jei_version=7.6.1.71

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -29,9 +29,9 @@ versionRange = "[${minecraft_version_min}]"
 ordering = "NONE"
 side = "BOTH"
 [[dependencies.oc2]]
-modId = "oc2-sedna"
+modId = "sedna"
 mandatory = true
-versionRange = "[${oc2_sedna_version_min},)"
+versionRange = "[${sedna_version_min},)"
 ordering = "NONE"
 side = "BOTH"
 [[dependencies.oc2]]


### PR DESCRIPTION
The mod was broken by the oc2-sedna -> sedna rename, causing forge to throw a "Dependency not found" screen up on startup.