### PR TITLE
Add support for class file parameter names

### DIFF
--- a/src/main/java/li/cil/oc2/api/bus/device/object/Callbacks.java
+++ b/src/main/java/li/cil/oc2/api/bus/device/object/Callbacks.java
@@ -213,7 +213,7 @@ public final class Callbacks {
                 final boolean hasName = annotation != null && Strings.isNotBlank(annotation.value());
                 final boolean hasDescription = annotation != null && Strings.isNotBlank(annotation.description());
 
-                this.name = hasName ? annotation.value() : null;
+                this.name = hasName ? annotation.value() : (parameter.isNamePresent() ? parameter.getName() : null);
 
                 if (parameterDescriptions.containsKey(this.name)) {
                     this.description = parameterDescriptions.get(this.name);


### PR DESCRIPTION
Class file parameter names were introduced in Java 8 via [JEP 118](https://openjdk.java.net/jeps/118), and can be opted-in with the `-parameters` compiler argument.

https://docs.oracle.com/javase/8/docs/api/java/lang/reflect/Parameter.html#isNamePresent--
https://docs.oracle.com/javase/8/docs/api/java/lang/reflect/Parameter.html#getName--

The only argument I see that could be made against supporting this is parameter names could be considered unstable for API usage, but so are method names, and OC2 already falls back to those when no explicit name is defined in a `Callback` annotation. So long as the API user remembers that their parameters are now exposed to reflection, it's equally stable - and the fact that it's opt-in on the compiler's side means this will not break existing code unless the API caller has consciously added the argument to their compiler configuration for any other purpose and is not actively using the provided `Parameter` annotation.