### PR TITLE
Add inspect method to robot HLAPI that returns name of block

### DIFF
--- a/src/main/java/li/cil/oc2/common/entity/Robot.java
+++ b/src/main/java/li/cil/oc2/common/entity/Robot.java
@@ -8,6 +8,7 @@ import li.cil.oc2.api.bus.device.object.ObjectDevice;
 import li.cil.oc2.api.bus.device.object.Parameter;
 import li.cil.oc2.api.bus.device.provider.ItemDeviceQuery;
 import li.cil.oc2.api.capabilities.TerminalUserProvider;
+import li.cil.oc2.api.util.RobotOperationSide;
 import li.cil.oc2.common.Config;
 import li.cil.oc2.common.bus.AbstractDeviceBusElement;
 import li.cil.oc2.common.bus.CommonDeviceBusController;
@@ -864,6 +865,17 @@ public final class Robot extends Entity implements li.cil.oc2.api.capabilities.R
         @Callback
         public ItemStack getStackInSlot(@Parameter("slot") final int slot) {
             return inventory.getStackInSlot(slot);
+        }
+
+        @Callback(synchronize = false)
+        public String inspect(@Parameter("side") @Nullable final RobotOperationSide side) {
+            if (side == null) throw new IllegalArgumentException();
+            final Level level = Robot.this.level;
+            if (!(level instanceof final ServerLevel serverLevel)) {
+                throw new IllegalArgumentException();
+            }
+            final BlockPos pos = Robot.this.blockPosition();
+            return level.getBlockState(pos.relative(RobotOperationSide.toGlobal(Robot.this, side))).getBlock().getDescriptionId();
         }
 
         @Callback(synchronize = false)

--- a/src/main/scripts/lib/lua/robot.lua
+++ b/src/main/scripts/lib/lua/robot.lua
@@ -72,4 +72,9 @@ M.turnAsync = function(direction)
   end
 end
 
+M.inspect = function(direction)
+  direction = assert(direction, "no direction specified")
+  return robot:inspect(direction)
+end
+
 return M

--- a/src/main/scripts/lib/micropython/robot.py
+++ b/src/main/scripts/lib/micropython/robot.py
@@ -50,6 +50,11 @@ class Robot:
         while not self.device.turn(direction):
             time.sleep(1)
 
+    def inspect(self, direction):
+        if not direction:
+            raise Exception("no direction specified")
+        return self.device.inspect(direction)
+
     def _wait_for_last_action(self):
         id = self.device.getLastActionId()
         result = self.device.getActionResult(id)


### PR DESCRIPTION
This PR adds a new method to the robot API that allows the robot to examine a block next to it to the front, above, or below. The method returns a string in the form of "block.mod.item_name".

Up for discussion: should this be gated behind a component (I think not) and should the robot be able to inspect to the sides and behind (I don't feel strongly one way or another).