### PR TITLE
makes sound card cooldown configurable

### DIFF
--- a/src/main/java/li/cil/oc2/common/Config.java
+++ b/src/main/java/li/cil/oc2/common/Config.java
@@ -39,6 +39,7 @@ public final class Config {
     @Path("energy.items") public static int networkTunnelEnergyPerTick = 2;
 
     @Path("gameplay") public static ResourceLocation blockOperationsModuleToolTier = TierSortingRegistry.getName(Tiers.DIAMOND);
+    @Path("gameplay.devices") public static long soundCardCoolDownSeconds = 2;
 
     @Path("admin") public static UUID fakePlayerUUID = UUID.fromString("e39dd9a7-514f-4a2d-aa5e-b6030621416d");
     @Path("admin.network") public static int projectorAverageMaxBytesPerSecond = 160 * 1024;

--- a/src/main/java/li/cil/oc2/common/bus/device/rpc/item/SoundCardItemDevice.java
+++ b/src/main/java/li/cil/oc2/common/bus/device/rpc/item/SoundCardItemDevice.java
@@ -6,6 +6,7 @@ import li.cil.oc2.api.bus.device.object.Callback;
 import li.cil.oc2.api.bus.device.object.Parameter;
 import li.cil.oc2.common.util.BlockLocation;
 import li.cil.oc2.common.util.TickUtils;
+import li.cil.oc2.common.Config;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvent;
@@ -21,7 +22,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 public final class SoundCardItemDevice extends AbstractItemRPCDevice {
-    private static final int COOLDOWN_IN_TICKS = TickUtils.toTicks(Duration.ofSeconds(2));
+    private static final int COOLDOWN_IN_TICKS = TickUtils.toTicks(Duration.ofSeconds(Config.soundCardCoolDownSeconds));
     private static final int MAX_FIND_RESULTS = 25;
 
     ///////////////////////////////////////////////////////////////////

--- a/src/main/java/li/cil/oc2/common/bus/device/rpc/item/SoundCardItemDevice.java
+++ b/src/main/java/li/cil/oc2/common/bus/device/rpc/item/SoundCardItemDevice.java
@@ -40,6 +40,16 @@ public final class SoundCardItemDevice extends AbstractItemRPCDevice {
 
     @Callback
     public void playSound(@Nullable @Parameter("name") final String name) {
+        playSound(name, 1, 1);
+    }
+
+    @Callback
+    public void playSound(@Nullable @Parameter("name") final String name, @Parameter("volume") final float volume) {
+        playSound(name, volume, 1);
+    }
+    
+    @Callback
+    public void playSound(@Nullable @Parameter("name") final String name, @Parameter("volume") final float volume, @Parameter("pitch") final float pitch) {
         if (name == null) throw new IllegalArgumentException();
 
         location.get().ifPresent(location -> location.tryGetLevel().ifPresent(level -> {
@@ -56,7 +66,7 @@ public final class SoundCardItemDevice extends AbstractItemRPCDevice {
 
             final SoundEvent soundEvent = ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation(name));
             if (soundEvent == null) throw new IllegalArgumentException("Sound not found.");
-            level.playSound(null, location.blockPos(), soundEvent, SoundSource.BLOCKS, 1, 1);
+            level.playSound(null, location.blockPos(), soundEvent, SoundSource.BLOCKS, volume, pitch);
         }));
     }
 

--- a/src/main/resources/assets/oc2/doc/en_us/item/sound_card.md
+++ b/src/main/resources/assets/oc2/doc/en_us/item/sound_card.md
@@ -12,8 +12,10 @@ This is a high level device. It must be controlled using the high level device A
 Device name: `sound`
 
 ### Methods
-`playSound(name:string)` plays back the sound effect with the specified name.
+`playSound(name:string[,volume,pitch])` plays back the sound effect with the specified name.
 - `name` is the name of the effect to play.
+- `volume` is the volume at which to play the effect, with `1` being the normal volume. Optional, defaulting to `1`.
+- `pitch` is the volume at which to play the effect, with `1` being the normal pitch. Optional, defaulting to `1`.
 - Throws if the specified name is invalid.
 
 `findSound(name:string):table` returns a list of available sound effects matching the given name. Note that the number of results is limited, so overly generic queries will result in truncated results.


### PR DESCRIPTION
currently uses seconds, but could be adjusted to use milliseconds instead. i put the configuration option into `gameplay.devices`, but there may be a better section.