### PR TITLE
make sound card cooldown configurable

### DIFF
--- a/src/main/java/li/cil/oc2/common/Config.java
+++ b/src/main/java/li/cil/oc2/common/Config.java
@@ -39,7 +39,7 @@ public final class Config {
     @Path("energy.items") public static int networkTunnelEnergyPerTick = 2;
 
     @Path("gameplay") public static ResourceLocation blockOperationsModuleToolTier = TierSortingRegistry.getName(Tiers.DIAMOND);
-    @Path("gameplay.devices") public static long soundCardCoolDownSeconds = 2;
+    @Path("gameplay") public static long soundCardCoolDownSeconds = 2;
 
     @Path("admin") public static UUID fakePlayerUUID = UUID.fromString("e39dd9a7-514f-4a2d-aa5e-b6030621416d");
     @Path("admin.network") public static int projectorAverageMaxBytesPerSecond = 160 * 1024;

--- a/src/main/java/li/cil/oc2/common/Config.java
+++ b/src/main/java/li/cil/oc2/common/Config.java
@@ -39,6 +39,7 @@ public final class Config {
     @Path("energy.items") public static int networkTunnelEnergyPerTick = 2;
 
     @Path("gameplay") public static ResourceLocation blockOperationsModuleToolTier = TierSortingRegistry.getName(Tiers.DIAMOND);
+    @Path("gameplay.devices") public static long soundCardCoolDownSeconds = 2;
 
     @Path("admin") public static UUID fakePlayerUUID = UUID.fromString("e39dd9a7-514f-4a2d-aa5e-b6030621416d");
     @Path("admin.network") public static int projectorAverageMaxBytesPerSecond = 160 * 1024;

--- a/src/main/java/li/cil/oc2/common/bus/device/rpc/item/SoundCardItemDevice.java
+++ b/src/main/java/li/cil/oc2/common/bus/device/rpc/item/SoundCardItemDevice.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 public final class SoundCardItemDevice extends AbstractItemRPCDevice {
-    private static final int COOLDOWN_IN_TICKS = TickUtils.toTicks(Duration.ofSeconds(Config.soundCardCoolDownSeconds));
+    private final int COOLDOWN_IN_TICKS = TickUtils.toTicks(Duration.ofSeconds(Config.soundCardCoolDownSeconds));
     private static final int MAX_FIND_RESULTS = 25;
 
     ///////////////////////////////////////////////////////////////////

--- a/src/main/java/li/cil/oc2/common/bus/device/rpc/item/SoundCardItemDevice.java
+++ b/src/main/java/li/cil/oc2/common/bus/device/rpc/item/SoundCardItemDevice.java
@@ -6,6 +6,7 @@ import li.cil.oc2.api.bus.device.object.Callback;
 import li.cil.oc2.api.bus.device.object.Parameter;
 import li.cil.oc2.common.util.BlockLocation;
 import li.cil.oc2.common.util.TickUtils;
+import li.cil.oc2.common.Config;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvent;
@@ -21,7 +22,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 public final class SoundCardItemDevice extends AbstractItemRPCDevice {
-    private static final int COOLDOWN_IN_TICKS = TickUtils.toTicks(Duration.ofSeconds(2));
+    private static final int COOLDOWN_IN_TICKS = TickUtils.toTicks(Duration.ofSeconds(Config.soundCardCoolDownSeconds));
     private static final int MAX_FIND_RESULTS = 25;
 
     ///////////////////////////////////////////////////////////////////


### PR DESCRIPTION
currently uses seconds, but could be adjusted to use milliseconds instead. i put the configuration option into gameplay.devices, but there may be a better section.
