### PR TITLE
Fixed getRedstoneInput function on redstone interface card and block.

### DIFF
--- a/src/main/java/li/cil/oc2/common/blockentity/RedstoneInterfaceBlockEntity.java
+++ b/src/main/java/li/cil/oc2/common/blockentity/RedstoneInterfaceBlockEntity.java
@@ -76,7 +76,7 @@ public final class RedstoneInterfaceBlockEntity extends ModBlockEntity implement
         assert direction != null;
 
         final BlockPos neighborPos = pos.relative(direction);
-        final ChunkPos chunkPos = new ChunkPos(neighborPos.getX(), neighborPos.getZ());
+        final ChunkPos chunkPos = new ChunkPos(neighborPos);
         if (!level.hasChunk(chunkPos.x, chunkPos.z)) {
             return 0;
         }

--- a/src/main/java/li/cil/oc2/common/bus/device/rpc/item/RedstoneInterfaceCardItemDevice.java
+++ b/src/main/java/li/cil/oc2/common/bus/device/rpc/item/RedstoneInterfaceCardItemDevice.java
@@ -93,7 +93,7 @@ public final class RedstoneInterfaceCardItemDevice extends AbstractItemRPCDevice
         assert direction != null;
 
         final BlockPos neighborPos = pos.relative(direction);
-        final ChunkPos chunkPos = new ChunkPos(neighborPos.getX(), neighborPos.getZ());
+        final ChunkPos chunkPos = new ChunkPos(neighborPos);
         if (!level.hasChunk(chunkPos.x, chunkPos.z)) {
             return 0;
         }


### PR DESCRIPTION
Fixes #157. `ChunkPos` Constructor was initialized incorrectly which caused incorrect behavior inside the getRedstoneInput functions.