### PR TITLE
Improve file import (error) logging

### DIFF
--- a/src/main/java/li/cil/oc2/common/bus/device/rpc/item/FileImportExportCardItemDevice.java
+++ b/src/main/java/li/cil/oc2/common/bus/device/rpc/item/FileImportExportCardItemDevice.java
@@ -224,6 +224,11 @@ public final class FileImportExportCardItemDevice extends AbstractItemRPCDevice 
     @Nullable
     @Callback(name = BEGIN_IMPORT_FILE)
     public ImportedFileInfo beginImportFile() {
+        if (state == State.IMPORT_CANCELED) {
+            reset();
+            throw new IllegalStateException("import was canceled");
+        }
+
         if (state != State.IMPORT_REQUESTED) {
             throw new IllegalStateException("invalid state");
         }

--- a/src/main/scripts/bin/import.lua
+++ b/src/main/scripts/bin/import.lua
@@ -46,8 +46,26 @@ local function file_exists(path)
     end
 end
 
+local function is_dir(path)
+    if not file_exists(path) then
+        return false
+    end
+
+    local f = io.open(path, "r")
+    local _, _, code = f:read(1)
+    f:close()
+    return code == 21
+end
+
 while file_exists(name) do
-    io.write("File '" .. name .. "' exists. [O]verwrite/[U]se another name/[C]ancel? ")
+    io.write("File '" .. name .. "' exists. ")
+
+    local is_dir = is_dir(name)
+    if not is_dir then
+        io.write("[O]verwrite/")
+    end
+
+    io.write("[U]se another name/[C]ancel? ")
     io.flush()
     local choice = io.read()
     if not choice or choice == "" or choice == "c" or choice == "C" then
@@ -56,8 +74,11 @@ while file_exists(name) do
         io.write("Enter new name: ")
         io.flush()
         name = io.read()
-    else
+    elseif not is_dir and (choice == "o" or choice == "O") then
         break
+    else
+        io.stderr:write("Invalid option: " .. choice .. "\n")
+        os.exit(1)
     end
 end
 

--- a/src/main/scripts/bin/import.lua
+++ b/src/main/scripts/bin/import.lua
@@ -11,13 +11,24 @@ end
 device:reset()
 
 if not device:requestImportFile() then
-    io.write("No users present to request file from.\n")
+    io.stderr:write("No users present to request file from.\n")
+    os.exit(1)
+end
+
+local function error_handler(err)
+    if err:match("import was canceled$") then
+        io.stderr:write("Import was calceled by the user.\n")
+    else
+        io.stderr:write(debug.traceback(err, 2))
+        io.stderr:write("\n")
+    end
     os.exit(1)
 end
 
 local name, size
 while true do
-    local info = device:beginImportFile()
+    local _, info = xpcall(device.beginImportFile, error_handler, device)
+
     if info then
         name = arg[1] or info.name or "imported"
         size = info.size
@@ -50,7 +61,7 @@ while file_exists(name) do
     end
 end
 
-io.write("Importing ")
+io.write("Importing " .. name)
 io.flush()
 
 local file = assert(io.open(name, "wb"))


### PR DESCRIPTION
This PR improves the log output of file imports in a few cases.
# Changes:
 * Make `FileImportExportCardItemDevice#beginImportFile` also handle `IMPORT_CANCELED` state
   since that method receives it when the cancel button is clicked during import.lua execution
 * Write no users present message to stderr instead of stdout
 * Stop import canceled error from printing an useless stacktrace
 * Add imported file name to log as part of the "Importing" line
 * Don't show the "Override" option when importing files with the name of an existing directory