### PR TITLE
Specify a correct RenderBoundingBox for Charger Block

### DIFF
--- a/src/main/java/li/cil/oc2/common/blockentity/ChargerBlockEntity.java
+++ b/src/main/java/li/cil/oc2/common/blockentity/ChargerBlockEntity.java
@@ -38,11 +38,16 @@ public final class ChargerBlockEntity extends ModBlockEntity implements NamedDev
 
     private final FixedEnergyStorage energy = new FixedEnergyStorage(Config.chargerEnergyStorage);
     private boolean isCharging;
+    private final AABB cachedRenderAABB;
 
     ///////////////////////////////////////////////////////////////////
 
     ChargerBlockEntity(final BlockPos pos, final BlockState state) {
         super(BlockEntities.CHARGER.get(), pos, state);
+        cachedRenderAABB = new AABB(
+            getBlockPos().offset(0, 1, 0),
+            getBlockPos().offset(1, 2, 1)
+        );
     }
 
     ///////////////////////////////////////////////////////////////////
@@ -156,9 +161,6 @@ public final class ChargerBlockEntity extends ModBlockEntity implements NamedDev
 
     @Override
     public AABB getRenderBoundingBox() {
-        return new AABB(
-            getBlockPos().offset(0, 1, 0),
-            getBlockPos().offset(1, 2, 1)
-        );
+        return cachedRenderAABB;
     }
 }

--- a/src/main/java/li/cil/oc2/common/blockentity/ChargerBlockEntity.java
+++ b/src/main/java/li/cil/oc2/common/blockentity/ChargerBlockEntity.java
@@ -153,4 +153,12 @@ public final class ChargerBlockEntity extends ModBlockEntity implements NamedDev
             isCharging = true;
         }
     }
+
+    @Override
+    public AABB getRenderBoundingBox() {
+        return new AABB(
+            getBlockPos().offset(0, 1, 0),
+            getBlockPos().offset(1, 2, 1)
+        );
+    }
 }


### PR DESCRIPTION
As of now, charger's "rings" are only visible when the block itself is inside the player's view, meaning that sometimes they can't be seen when they should be.
This pull request fixes this by specifying a correct RenderBoundingBox for the Charger Block.