### PR TITLE
Collection of RPC device documentation changes

### DIFF
--- a/src/main/java/li/cil/oc2/common/bus/device/rpc/ItemHandlerDevice.java
+++ b/src/main/java/li/cil/oc2/common/bus/device/rpc/ItemHandlerDevice.java
@@ -27,12 +27,12 @@ public final class ItemHandlerDevice extends IdentityProxy<IItemHandler> impleme
     }
 
     @Callback
-    public ItemStack getItemStackInSlot(final int slot) {
+    public ItemStack getItemStackInSlot(@Parameter("slot") final int slot) {
         return identity.getStackInSlot(slot);
     }
 
     @Callback
-    public int getItemSlotLimit(final int slot) {
+    public int getItemSlotLimit(@Parameter("slot") final int slot) {
         return identity.getSlotLimit(slot);
     }
 }

--- a/src/main/java/li/cil/oc2/common/bus/device/rpc/ItemHandlerDevice.java
+++ b/src/main/java/li/cil/oc2/common/bus/device/rpc/ItemHandlerDevice.java
@@ -3,6 +3,7 @@
 package li.cil.oc2.common.bus.device.rpc;
 
 import li.cil.oc2.api.bus.device.object.Callback;
+import li.cil.oc2.api.bus.device.object.Parameter;
 import li.cil.oc2.api.bus.device.object.NamedDevice;
 import li.cil.oc2.common.bus.device.util.IdentityProxy;
 import net.minecraft.world.item.ItemStack;

--- a/src/main/resources/assets/oc2/doc/en_us/item/block_operations_module.md
+++ b/src/main/resources/assets/oc2/doc/en_us/item/block_operations_module.md
@@ -16,7 +16,7 @@ The side parameter in the following methods represents a direction from the pers
 
 ### Methods
 `excavate([side]):boolean` tries to break a block in the specified direction. Collected blocks will be inserted starting at the currently selected inventory slot. If the selected slot is full, the next slot will be used, and so on. If the inventory has no space for the dropped block, it will drop into the world.
-- `side` is the relative direction in to break a block in. Optional, defaults to `front`. See the "Sides" section.
+- `side` is the relative direction to break a block in. Optional, defaults to `front`. See the "Sides" section.
 - Returns whether the operation was successful.
 
 `place([side]):boolean` tries to place a block in the specified direction. Blocks will be placed from the currently selected inventory slot. If the slot is empty, no block will be placed.

--- a/src/main/scripts/lib/lua/devices.lua
+++ b/src/main/scripts/lib/lua/devices.lua
@@ -26,9 +26,6 @@ Device.__tostring = function(self)
         end
         if p.name then
           doc = doc .. p.name
-        else
-          doc = doc .. "arg" .. i
-        end
         if p.type then
             doc = doc .. ": " .. p.type
         end

--- a/src/main/scripts/lib/micropython/devices.py
+++ b/src/main/scripts/lib/micropython/devices.py
@@ -26,8 +26,6 @@ class Device:
                         doc += ", "
                     if "name" in p:
                         doc += p["name"]
-                    else:
-                        doc += "arg" + str(i)
                     if "type" in p:
                         doc += ": " + p["type"]
                     i += 1


### PR DESCRIPTION
**Disclaimer: I have no experience with java, nor have these changes been built and tested locally. So please validate them on your side (I'd be happy to do this myself, but don't know how).**

Commits:

- `Added parameter names to RPC device handlers where missing, Deleted missing parameter name handling in scripts/lib/*/devices.*`

_I believe I have checked the documentation for all of the RPC devices.
Here is the list of (all?) the RPC device typeNames that I have checked; `"robot"`, `"inventory_operations"`, `"block_operations"`, `"redstone"`, `"item_handler"`, `"oc2:computer"`, `"energy_storage"`, `"file_import_export"`, `"sound"`
The `"item_handler"` device is the only one without named parameters. This commit provides the parameter names and thus negates the requirement for handling un-named parameters in `scripts/lib/*/devices.*`.
This script will print the documentation for an available device's methods (split at the 80th character):_
```
d_tn = "item_handler"

for line in str(d_bus.find(type_name=d_tn)).split("\n"):
    doc = ""
    for index, char in enumerate(line):
        if index > 0 and index % 80 == 0:
            doc += "\n"
        doc += char
    print(doc)
```
_Output:_
```
getItemSlotCount(): int
getItemStackInSlot(arg0: int): ItemStack
getItemSlotLimit(arg0: int): int
...
```

- `Attempted to provide device documentation for BlockOperationsModuleDevice`

_I have attempted to provide `getDeviceDocumentation` for `BlockOperationsModuleDevice.java` following the format of `RedstoneInterfaceCardItemDevice.java` with the documentation in `block_operations_module.md`.
I would be happy to do the same for all of the remaining devices without `getDeviceDocumentation`. Please let me know if you would like me to do this, and of course, any and all feedback is appreciated. 
Given my disclaimer above there's a decent chance I've not done this right. Also, I had to take a guess at the prefferred max line-width._
